### PR TITLE
feat(api): add api and nullable modules

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,166 @@
+// Package api provides convenience methods and types for interacting with
+// a JSON API over http.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	defaultMaxQPS = 10
+	mediaType     = "application/json"
+	userAgent     = "LobGo/0.0.0" // TODO(damian): figure out how we want to handle versioning
+)
+
+// The Client interface defines methods for interacting with an HTTP API.
+type Client interface {
+	NewRequest(context.Context, string, string, interface{}) (*http.Request, error)
+	NewMultiformRequest(context.Context, string, string, *bytes.Buffer) (*http.Request, error)
+	Do(*http.Request) (*http.Response, error)
+}
+
+// JSONClient implements the Client interface and provides convenience methods for constructing
+// and executing JSON http requests.
+type JSONClient struct {
+	opts   *Options
+	client *http.Client
+
+	throttle <-chan time.Time
+}
+
+// Options contains necessary configuration for a Client.
+type Options struct {
+	BaseURL    string
+	APIKey     string
+	MaxQPS     int
+	APIVersion string
+}
+
+// NewRequest creates a new http.Request for the specified method and path, with the given body encoded as JSON.
+func (c *JSONClient) NewRequest(ctx context.Context, method string, relPath string, body interface{}) (*http.Request, error) {
+	// Ensure that the given relative path is a valid URL.
+	rel, err := url.Parse(relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := &bytes.Buffer{}
+	if body != nil {
+		if err = json.NewEncoder(buf).Encode(body); err != nil {
+			return nil, err
+		}
+	}
+
+	path := fmt.Sprintf("%s/%s", c.opts.BaseURL, rel.String())
+	req, err := http.NewRequest(method, path, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+
+	req.Header.Add("Accept", mediaType)
+	req.Header.Add("Content-Type", mediaType)
+	req.Header.Add("User-Agent", userAgent)
+	req.SetBasicAuth(c.opts.APIKey, "")
+
+	if c.opts.APIVersion != "" {
+		req.Header.Add("Lob-Version", c.opts.APIVersion)
+	}
+
+	return req, nil
+}
+
+// NewMultiformRequest creates a new multipart form http.Request for the specified path (relative to the Client's BaseURL).
+// The contentType needs to include the form boundary, and the payload buffer needs to be properly formatted.
+func (c *JSONClient) NewMultiformRequest(ctx context.Context, relPath string, contentType string, formPayload *bytes.Buffer) (*http.Request, error) {
+	// Ensure that the given relative path is a valid URL.
+	rel, err := url.Parse(relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("%s/%s", c.opts.BaseURL, rel.String())
+	req, err := http.NewRequest("POST", path, formPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+
+	req.Header.Add("Accept", mediaType)
+	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("User-Agent", userAgent)
+	req.SetBasicAuth(c.opts.APIKey, "")
+
+	if c.opts.APIVersion != "" {
+		req.Header.Add("Lob-Version", c.opts.APIVersion)
+	}
+
+	return req, nil
+}
+
+// Do executes the given http.Request and returns an http.Response or error.
+func (c *JSONClient) Do(req *http.Request) (*http.Response, error) {
+	<-c.throttle
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = CheckError(resp); err != nil {
+		return nil, err
+	}
+
+	return resp, err
+}
+
+// NewJSONClient creates a new JSONCLient object with the given options.
+func NewJSONClient(opt *Options) *JSONClient {
+	if opt.MaxQPS <= 0 {
+		opt.MaxQPS = defaultMaxQPS
+	}
+
+	rate := time.Second / time.Duration(opt.MaxQPS)
+	throttle := time.Tick(rate)
+
+	return &JSONClient{
+		opts:     opt,
+		client:   &http.Client{},
+		throttle: throttle,
+	}
+}
+
+// Deserialize deserializes from.Body as JSON into the specified interface.
+// Note: clients are responsible for closing from.Body; Deserialize does not do so.
+func Deserialize(from *http.Response, to interface{}) error {
+	return json.NewDecoder(from.Body).Decode(to)
+}
+
+// CheckError deserializes any errors present in the given http.Response.
+func CheckError(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	errMsg := new(struct {
+		Err struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	})
+
+	err := json.NewDecoder(resp.Body).Decode(errMsg)
+	if err != nil {
+		return err
+	}
+
+	return errors.New(errMsg.Err.Message)
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewJSONClient(&Options{"foo.com", "api_key", 0, ""})
+
+	if c.opts == nil {
+		t.Fatalf("NewClient: unable to set client Options")
+	}
+
+	if c.opts.MaxQPS != defaultMaxQPS {
+		t.Errorf("NewClient: unable to set default MaxQPS")
+	}
+
+	if c.client == nil {
+		t.Errorf("NewClient: unable to create http.Client")
+	}
+}
+
+func TestNewRequest(t *testing.T) {
+	c := NewJSONClient(&Options{"foo.com", "api_key", 10, "2017-10-17"})
+
+	var tests = []struct {
+		label     string
+		method    string
+		relPath   string
+		body      interface{}
+		shouldErr bool
+	}{
+		{"ValidRequest", "GET", "v1/foo", nil, false},
+		{"ValidRequestWithPayload", "POST", "v1/foo", map[string]string{"foo": "bar"}, false},
+		{"BadURL", "GET", "@wtf@http://@\\", nil, true},
+		{"BadJSON", "GET", "v1/foo", make(chan int), true},
+		{"BadMethod", "SOMETHING FAKE", "v1/foo", nil, true},
+	}
+
+	for _, test := range tests {
+		_, err := c.NewRequest(context.Background(), test.method, test.relPath, test.body)
+		if err == nil && test.shouldErr {
+			t.Errorf("%s failed: error was expected but not received", test.label)
+		}
+		if err != nil && !test.shouldErr {
+			t.Errorf("%s failed: unexpected error encountered: %s", test.label, err)
+		}
+	}
+}
+
+func TestNewMultiformRequest(t *testing.T) {
+	c := NewJSONClient(&Options{"foo.com", "api_key", 10, "2017-10-17"})
+
+	var tests = []struct {
+		label     string
+		relPath   string
+		body      *bytes.Buffer
+		shouldErr bool
+	}{
+		{"ValidRequest", "v1/foo", &bytes.Buffer{}, false},
+		{"BadURL", "@wtf@http://@\\", &bytes.Buffer{}, true},
+	}
+
+	for _, test := range tests {
+		_, err := c.NewMultiformRequest(context.Background(), test.relPath, "some fake content type", test.body)
+		if err == nil && test.shouldErr {
+			t.Errorf("%s failed: error was expected but not received", test.label)
+		}
+	}
+}
+
+func TestDo(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	client := NewJSONClient(&Options{srv.URL, "api_key", 10, ""})
+	defer srv.Close()
+
+	mux.HandleFunc("/pass", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/fail", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	goodReq, _ := client.NewRequest(context.Background(), "GET", "pass", nil)
+	badReq, _ := client.NewRequest(context.Background(), "GET", "fail", nil)
+
+	tests := []struct {
+		label     string
+		req       *http.Request
+		shouldErr bool
+	}{
+		{"ValidRequest", goodReq, false},
+		{"BadResponse", badReq, true},
+	}
+
+	for _, test := range tests {
+		_, err := client.Do(test.req)
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("%s: expected error", test.label)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected error %#v: %s", test.label, err, err)
+			}
+		}
+	}
+}
+
+func TestCheckError(t *testing.T) {
+	msg := `{"error":{"message":"fail","status_code":500}}`
+
+	tests := []struct {
+		label     string
+		resp      *http.Response
+		shouldErr bool
+		errMsg    string
+	}{
+		{"GoodResponse",
+			&http.Response{
+				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				StatusCode: http.StatusOK,
+			},
+			false,
+			"",
+		},
+		{"StatusCodeError",
+			&http.Response{
+				Body:       ioutil.NopCloser(strings.NewReader(msg)),
+				StatusCode: http.StatusInternalServerError,
+			},
+			true,
+			msg,
+		},
+		{"BadResponseBodyError",
+			&http.Response{
+				Body:       ioutil.NopCloser(strings.NewReader("fail")),
+				StatusCode: http.StatusInternalServerError,
+			},
+			true,
+			"fail",
+		},
+	}
+
+	for _, test := range tests {
+		err := CheckError(test.resp)
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("%s: expected error", test.label)
+			}
+			if err.Error() == test.errMsg {
+				t.Errorf("%s: bad error message, expected %s, actual %s", test.label, test.errMsg, err.Error())
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected error %s", test.label, err)
+			}
+		}
+	}
+}
+
+func TestDeserialize(t *testing.T) {
+	type testType struct {
+		OK bool
+	}
+
+	tests := []struct {
+		label     string
+		from      *http.Response
+		to        interface{}
+		shouldErr bool
+	}{
+		{"DeserializationSucceeds",
+			&http.Response{
+				Body: ioutil.NopCloser(strings.NewReader(`{"ok":true}`)),
+			},
+			&testType{},
+			false,
+		},
+		{"TargetMismatch",
+			&http.Response{
+				Body: ioutil.NopCloser(strings.NewReader(`{"notBool":what?}`)),
+			},
+			&testType{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		err := Deserialize(test.from, test.to)
+		if err == nil && test.shouldErr {
+			t.Errorf("%s: expected error", test.label)
+		}
+		if !test.shouldErr {
+			if err != nil {
+				t.Errorf("%s: unexpected error %s", test.label, err)
+			}
+			if !test.to.(*testType).OK {
+				t.Errorf("%s: json deserialization failed", test.label)
+			}
+		}
+	}
+}

--- a/lob.go
+++ b/lob.go
@@ -1,0 +1,3 @@
+package lob
+
+// Placeholder to keep build rule happy until functionality is ready.

--- a/nullable/nullable.go
+++ b/nullable/nullable.go
@@ -1,0 +1,156 @@
+package nullable
+
+import (
+	"encoding/json"
+)
+
+// Int represents a nullable integer.
+type Int struct {
+	value int
+	valid bool
+}
+
+// NewInt creates a new Bool with the given value.
+func NewInt(i int) Int {
+	return Int{
+		value: i,
+		valid: true,
+	}
+}
+
+// Set sets the value of the Int.
+func (i *Int) Set(val int) {
+	i.value = val
+	i.valid = true
+}
+
+// Clear clears the current Int and marks it as invalid.
+func (i *Int) Clear() {
+	i.value = 0
+	i.valid = false
+}
+
+// Value returns the current value of the Int, and whether it is valid.
+func (i *Int) Value() (int, bool) {
+	return i.value, i.valid
+}
+
+// MarshalJSON implments the Marshaler interface for Int.
+func (i Int) MarshalJSON() ([]byte, error) {
+	return marshalOrNull(i.Value())
+}
+
+// String represents a nullable string.
+type String struct {
+	value string
+	valid bool
+}
+
+// NewString creates a new String with the given value
+func NewString(s string) String {
+	return String{
+		value: s,
+		valid: true,
+	}
+}
+
+// Set sets the value of the String.
+func (s *String) Set(val string) {
+	s.value = val
+	s.valid = true
+}
+
+// Clear clears the current String and marks it as invalid.
+func (s *String) Clear() {
+	s.value = ""
+	s.valid = false
+}
+
+// Value returns the current value of the String, and whether it is valid.
+func (s *String) Value() (string, bool) {
+	return s.value, s.valid
+}
+
+// MarshalJSON implments the Marshaler interface for String.
+func (s String) MarshalJSON() ([]byte, error) {
+	return marshalOrNull(s.Value())
+}
+
+// Float represents a nullable float64.
+type Float struct {
+	value float64
+	valid bool
+}
+
+// NewFloat creates a new Float with the given value
+func NewFloat(f float64) Float {
+	return Float{
+		value: f,
+		valid: true,
+	}
+}
+
+// Set sets the value of the Float.
+func (f *Float) Set(val float64) {
+	f.value = val
+	f.valid = true
+}
+
+// Clear clears the current Float and marks it as invalid.
+func (f *Float) Clear() {
+	f.value = 0
+	f.valid = false
+}
+
+// Value returns the current value of the Float, and whether it is valid.
+func (f *Float) Value() (float64, bool) {
+	return f.value, f.valid
+}
+
+// MarshalJSON implments the Marshaler interface for Float.
+func (f Float) MarshalJSON() ([]byte, error) {
+	return marshalOrNull(f.Value())
+}
+
+// Bool represents a nullable bool.
+type Bool struct {
+	value bool
+	valid bool
+}
+
+// NewBool creates a new Bool with the given value
+func NewBool(b bool) Bool {
+	return Bool{
+		value: b,
+		valid: true,
+	}
+}
+
+// Set sets the value of the Bool.
+func (b *Bool) Set(val bool) {
+	b.value = val
+	b.valid = true
+}
+
+// Clear clears the current Bool and marks it as invalid.
+func (b *Bool) Clear() {
+	b.value = false
+	b.valid = false
+}
+
+// Value returns the current value of the Bool, and whether it is valid.
+func (b *Bool) Value() (bool, bool) {
+	return b.value, b.valid
+}
+
+// MarshalJSON implments the Marshaler interface for Bool.
+func (b Bool) MarshalJSON() ([]byte, error) {
+	return marshalOrNull(b.Value())
+}
+
+func marshalOrNull(val interface{}, ok bool) ([]byte, error) {
+	if !ok {
+		return []byte("null"), nil
+	}
+	return json.Marshal(val)
+}

--- a/nullable/nullable_test.go
+++ b/nullable/nullable_test.go
@@ -1,0 +1,176 @@
+package nullable
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	exp := "foo"
+	var zero string
+	s := NewString(exp)
+
+	val, ok := s.Value()
+	if !ok {
+		t.Errorf("TestString: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestString: expected: %s, actual: %s", exp, val)
+	}
+
+	json, _ := s.MarshalJSON()
+	if string(json) != fmt.Sprintf(`"%s"`, exp) {
+		t.Errorf("TestString: error marshaling JSON")
+	}
+
+	s.Clear()
+	val, ok = s.Value()
+	if ok {
+		t.Errorf("TestString: expected null value")
+	}
+	if val != zero {
+		t.Errorf("TestString: expected empty string")
+	}
+
+	json, _ = s.MarshalJSON()
+	if string(json) != "null" {
+		t.Errorf("TestString: error marshaling JSON")
+
+	}
+
+	s.Set(exp)
+	val, ok = s.Value()
+	if !ok {
+		t.Errorf("TestString: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestString: expected: %s, actual: %s", exp, val)
+	}
+}
+
+func TestInt(t *testing.T) {
+	var zero int
+	exp := 3
+	s := NewInt(exp)
+
+	val, ok := s.Value()
+	if !ok {
+		t.Errorf("TestInt: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestInt: expected: %d, actual: %d", exp, val)
+	}
+
+	json, _ := s.MarshalJSON()
+	if string(json) != fmt.Sprintf("%d", exp) {
+		t.Errorf("TestInt: error marshaling JSON")
+	}
+
+	s.Clear()
+	val, ok = s.Value()
+	if ok {
+		t.Errorf("TestInt: expected null value")
+	}
+	if val != zero {
+		t.Errorf("TestInt: expected %d", zero)
+	}
+
+	json, _ = s.MarshalJSON()
+	if string(json) != "null" {
+		t.Errorf("TestInt: error marshaling JSON")
+	}
+
+	s.Set(exp)
+	val, ok = s.Value()
+	if !ok {
+		t.Errorf("TestInt: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestInt: expected: %d, actual: %d", exp, val)
+	}
+}
+
+func TestFloat(t *testing.T) {
+	var zero float64
+	exp := 1.35
+	s := NewFloat(exp)
+
+	val, ok := s.Value()
+	if !ok {
+		t.Errorf("TestFloat: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestFloat: expected: %f, actual: %f", exp, val)
+	}
+
+	json, _ := s.MarshalJSON()
+	if string(json) != fmt.Sprintf("%.2f", exp) {
+		t.Errorf("TestFloat: error marshaling JSON")
+	}
+
+	s.Clear()
+	val, ok = s.Value()
+	if ok {
+		t.Errorf("TestFloat: expected null value")
+	}
+	if val != zero {
+		t.Errorf("TestFloat: expected expected %f", zero)
+	}
+
+	json, _ = s.MarshalJSON()
+	if string(json) != "null" {
+		t.Errorf("TestFloat: error marshaling JSON")
+	}
+
+	s.Set(exp)
+	val, ok = s.Value()
+	if !ok {
+		t.Errorf("TestFloat: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestFloat: expected: %f, actual: %f", exp, val)
+	}
+}
+
+func TestBool(t *testing.T) {
+	var zero bool
+	exp := true
+	s := NewBool(exp)
+
+	val, ok := s.Value()
+	if !ok {
+		t.Errorf("TestBool: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestBool: expected: %v, actual: %v", exp, val)
+	}
+
+	json, _ := s.MarshalJSON()
+	if string(json) != fmt.Sprintf("%v", exp) {
+		t.Errorf("TestBool: error marshaling JSON")
+
+	}
+
+	s.Clear()
+	val, ok = s.Value()
+	if ok {
+		t.Errorf("TestBool: expected null value")
+	}
+	if val != zero {
+		t.Errorf("TestBool: expected %v", zero)
+	}
+
+	json, _ = s.MarshalJSON()
+	if string(json) != "null" {
+		t.Errorf("TestBool: error marshaling JSON")
+	}
+
+	s.Set(exp)
+	val, ok = s.Value()
+	if !ok {
+		t.Errorf("TestBool: expected non-null value")
+	}
+	if val != exp {
+		t.Errorf("TestBool: expected: %v, actual: %v", exp, val)
+	}
+}


### PR DESCRIPTION
### What:
- Adds `api` module, which includes convenience methods for interacting with a predominantly JSON API
- Adds `nullable` module, which provides a simple implementation of nullable primitives.

### Why:
The `api` module will be used extensively to interact with Lob's API. Since the API implicitly relies on fields that can be `null` in some places, the `nullable` module will be used to work around Go's lack of built-in nullable types