### PR TITLE
feat(scaffolds): add scaffold package for use in create requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,9 +37,20 @@ type JSONClient struct {
 
 // Options contains necessary configuration for a Client.
 type Options struct {
-	BaseURL    string
-	APIKey     string
-	MaxQPS     int
+	// BaseURL specifies the base target URL for a Client.
+	// Paths used in creating requests will interpreted as relative to this URL.
+	BaseURL string
+
+	// APIKey is the Lob API key that will be used to authenticate each request.
+	APIKey string
+
+	// MaxQPS is the maximum number of queries that a Client will attempt
+	// per second. This is client-side rate limiting, server-side rate
+	// limiting may enforce different limits.
+	MaxQPS int
+
+	// APIVersion is the version of the Lob API to be used. If no value is
+	// provided, it defaults to the most recent version of the API.
 	APIVersion string
 }
 

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -1,0 +1,182 @@
+package scaffold
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/lob/lob-go/nullable"
+)
+
+// Address scaffold wraps fields used to create an Address object in Lob API.
+type Address struct {
+	Name        nullable.String   `json:"name"`
+	Line1       string            `json:"address_line1"`
+	Line2       nullable.String   `json:"address_line2"`
+	City        nullable.String   `json:"address_city"`
+	Zip         nullable.String   `json:"address_zip"`
+	State       nullable.String   `json:"address_state"`
+	Country     nullable.String   `json:"address_country"`
+	Company     nullable.String   `json:"company"`
+	Email       nullable.String   `json:"email"`
+	Phone       nullable.String   `json:"phone"`
+	Description nullable.String   `json:"description"`
+	Metadata    map[string]string `json:"metadata"`
+}
+
+// BankAccount scaffold wraps fields used to create a BankAccount object in Lob API.
+type BankAccount struct {
+	AccountNumber string            `json:"account_number"`
+	AccountType   string            `json:"account_type"`
+	RoutingNumber string            `json:"routing_number"`
+	Signatory     string            `json:"signatory"`
+	Description   nullable.String   `json:"description"`
+	Metadata      map[string]string `json:"metadata"`
+}
+
+// Check scaffold wraps fields used to create a Check object in Lob API.
+type Check struct {
+	To             interface{}       `json:"to"`
+	From           interface{}       `json:"from"`
+	Description    nullable.String   `json:"description"`
+	BankAccount    string            `json:"bank_account"`
+	Logo           interface{}       `json:"logo"`
+	Amount         float64           `json:"amount"`
+	Message        nullable.String   `json:"message"`
+	CheckBottom    interface{}       `json:"check_bottom"`
+	Attachment     interface{}       `json:"attachment"`
+	MergeVariables map[string]string `json:"merge_variables"`
+	MailType       nullable.String   `json:"mail_type"`
+	SendDate       nullable.String   `json:"send_date"`
+	Metadata       map[string]string `json:"metadata"`
+}
+
+// Letter scaffold wraps fields used to create a Letter object in Lob API.
+type Letter struct {
+	To               interface{}       `json:"to"`
+	From             interface{}       `json:"from"`
+	File             interface{}       `json:"file"`
+	Color            bool              `json:"color"`
+	DoubleSided      nullable.Bool     `json:"double_sided"`
+	AddressPlacement nullable.String   `json:"address_placement"`
+	ReturnEnvelope   nullable.Bool     `json:"return_envelope"`
+	PerforatedPage   nullable.Int      `json:"perforated_page"`
+	ExtraService     nullable.String   `json:"extra_service"`
+	MergeVariables   map[string]string `json:"merge_variables"`
+	MailType         nullable.String   `json:"mail_type"`
+	SendDate         nullable.String   `json:"send_date"`
+	Description      string            `json:"description"`
+	Metadata         map[string]string `json:"metadata"`
+}
+
+// Postcard scaffold wraps fields used to create a Postcard object in Lob API.
+type Postcard struct {
+	To             interface{}       `json:"to"`
+	From           interface{}       `json:"from"`
+	Description    nullable.String   `json:"description"`
+	Front          interface{}       `json:"front"`
+	Back           interface{}       `json:"back"`
+	MergeVariables map[string]string `json:"merge_variables"`
+	Size           nullable.String   `json:"size"`
+	MailType       nullable.String   `json:"mail_type"`
+	SendDate       nullable.String   `json:"send_date"`
+	Metadata       map[string]string `json:"metadata"`
+}
+
+// MarshalAsFormValues attempts to coerce the fields of the given scaffold into strings,
+// and places them in a map formatted for use in a multipart form request.
+func MarshalAsFormValues(scaffold interface{}) (map[string]string, error) {
+	v := reflect.ValueOf(scaffold).Elem()
+	t := v.Type()
+	fields := make(map[string]string)
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("json")
+
+		val := v.FieldByName(field.Name).Interface()
+		if val == nil {
+			continue // Note: this branch is definitely hit by tests (if you remove it, you hit a seg fault), but doesn't show up in coverage.
+		}
+
+		switch fieldVal := val.(type) {
+		case int, int64, float64, bool, string, []string:
+			str := coerceToString(fieldVal)
+			if len(str) > 0 {
+				fields[tag] = str
+			}
+		case nullable.String:
+			s, ok := fieldVal.Value()
+			if ok {
+				str := coerceToString(s)
+				if len(str) > 0 {
+					fields[tag] = str
+				}
+			}
+		case nullable.Int:
+			i, ok := fieldVal.Value()
+			if ok {
+				str := coerceToString(i)
+				if len(str) > 0 {
+					fields[tag] = str
+				}
+			}
+		case nullable.Float:
+			f, ok := fieldVal.Value()
+			if ok {
+				str := coerceToString(f)
+				if len(str) > 0 {
+					fields[tag] = str
+				}
+			}
+		case nullable.Bool:
+			b, ok := fieldVal.Value()
+			if ok {
+				str := coerceToString(b)
+				if len(str) > 0 {
+					fields[tag] = str
+				}
+			}
+		case map[string]string:
+			for key, value := range fieldVal {
+				nestedTag := fmt.Sprintf("%s[%s]", tag, key)
+				fields[nestedTag] = value
+			}
+		case *Address, *BankAccount, *Check, *Letter, *Postcard:
+			nestedFieldMap, err := MarshalAsFormValues(fieldVal)
+			if err != nil {
+				return nil, err
+			}
+			for key, value := range nestedFieldMap {
+				nestedTag := fmt.Sprintf("%s[%s]", tag, key)
+				if len(value) > 0 {
+					fields[nestedTag] = value
+				}
+			}
+		case []byte:
+			continue
+		default:
+			return nil, fmt.Errorf("Unable to parse field: %s", field.Name)
+		}
+	}
+	return fields, nil
+}
+
+func coerceToString(val interface{}) string {
+	var output string
+	switch fieldVal := val.(type) {
+	case int:
+		output = strconv.Itoa(fieldVal)
+	case bool:
+		output = fmt.Sprintf("%v", fieldVal)
+	case int64:
+		output = strconv.FormatInt(fieldVal, 10)
+	case float64:
+		output = fmt.Sprintf("%.2f", fieldVal)
+	case string:
+		output = fieldVal
+	case []string:
+		output = strings.Join(fieldVal, " ")
+	}
+	return output
+}

--- a/scaffold/scaffold_test.go
+++ b/scaffold/scaffold_test.go
@@ -1,0 +1,147 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/lob/lob-go/nullable"
+)
+
+func TestStringCoercion(t *testing.T) {
+	tests := []struct {
+		label    string
+		val      interface{}
+		expected string
+	}{
+		{"int", 1, "1"},
+		{"int64", int64(1), "1"},
+		{"float64", float64(1.0), "1.00"},
+		{"bool", true, "true"},
+		{"string", "foo", "foo"},
+		{"[]string", []string{"1", "2"}, "1 2"},
+	}
+
+	for _, test := range tests {
+		s := coerceToString(test.val)
+		if s != test.expected {
+			t.Errorf("%s: expected string %s, actual: %s", test.label, test.expected, s)
+		}
+	}
+}
+
+func TestUnsupportedMarshalling(t *testing.T) {
+	intVal := 1
+	nestedPsc := &Postcard{
+		To: &intVal,
+	}
+	psc := &Postcard{
+		To: nestedPsc,
+	}
+	_, err := MarshalAsFormValues(psc)
+	if err == nil {
+		t.Errorf("Unsupported type: expected error coercing *int to string")
+	}
+
+}
+
+func TestAddressMarshalling(t *testing.T) {
+	expected := map[string]string{
+		"name":          "Larry Lobster",
+		"address_line1": "185 Berry St.",
+		"address_line2": "#6100",
+		"metadata[foo]": "bar",
+	}
+	addy := &Address{
+		Name:     nullable.NewString("Larry Lobster"),
+		Line1:    "185 Berry St.",
+		Line2:    nullable.NewString("#6100"),
+		Metadata: map[string]string{"foo": "bar"},
+	}
+
+	formVals, err := MarshalAsFormValues(addy)
+	if err != nil {
+		t.Errorf("Address: error marshalling scaffold to form values: %s", err)
+	}
+	for key, val := range formVals {
+		if val != expected[key] {
+			t.Errorf("Address: marshalling error for key %s. Expected %s, actual %s", key, expected[key], val)
+		}
+	}
+	for key, val := range expected {
+		if val != formVals[key] {
+			t.Errorf("Address: marshalling error. Missing expected key %s and value %s", key, val)
+		}
+	}
+}
+
+func TestPostcardMarshalling(t *testing.T) {
+	expected := map[string]string{
+		"to":                  "addr_12345",
+		"from[name]":          "Larry Lobster",
+		"from[address_line1]": "185 Berry St.",
+		"from[address_line2]": "#6100",
+		"back":                "1.00",
+	}
+	addy := &Address{
+		Name:  nullable.NewString("Larry Lobster"),
+		Line1: "185 Berry St.",
+		Line2: nullable.NewString("#6100"),
+	}
+	psc := &Postcard{
+		To:    "addr_12345",
+		From:  addy,
+		Front: []byte("some local file"),
+		Back:  nullable.NewFloat(1.0), // Note: this isn't a valid value for Back, we're just abusing the interface{} for testing purposes.
+	}
+
+	formVals, err := MarshalAsFormValues(psc)
+	if err != nil {
+		t.Errorf("Postcard: error marshalling scaffold to form values: %s", err)
+	}
+	for key, val := range formVals {
+		if val != expected[key] {
+			t.Errorf("Postcard: marshalling error for key %s. Expected %s, actual %s", key, expected[key], val)
+		}
+	}
+	for key, val := range expected {
+		if val != formVals[key] {
+			t.Errorf("Postcard: marshalling error. Missing expected key %s and value %s", key, val)
+		}
+	}
+}
+
+func TestLetterMarshalling(t *testing.T) {
+	expected := map[string]string{
+		"to":              "addr_12345",
+		"file":            "<html>an html string</html>",
+		"color":           "true",
+		"double_sided":    "true",
+		"perforated_page": "3",
+		"mail_type":       "standard",
+	}
+	ltr := &Letter{
+		To:             "addr_12345",
+		From:           nullable.Float{}, // Note: Same story as Back above, this is just meant to test nullable.Float marshalling.
+		File:           "<html>an html string</html>",
+		Color:          true,
+		DoubleSided:    nullable.NewBool(true),
+		ReturnEnvelope: nullable.Bool{},
+		PerforatedPage: nullable.NewInt(3),
+		MailType:       nullable.NewString("standard"),
+		SendDate:       nullable.String{},
+	}
+
+	formVals, err := MarshalAsFormValues(ltr)
+	if err != nil {
+		t.Errorf("Letter: error marshalling scaffold to form values: %s", err)
+	}
+	for key, val := range formVals {
+		if val != expected[key] {
+			t.Errorf("Letter: marshalling error for key %s. Expected %s, actual %s", key, expected[key], val)
+		}
+	}
+	for key, val := range expected {
+		if val != formVals[key] {
+			t.Errorf("Letter: marshalling error. Missing expected key %s and value %s", key, val)
+		}
+	}
+}


### PR DESCRIPTION
### What:
- Adds `scaffold`  package
- Adds support for serializing scaffolds as multipart form values
- Adds comments to `api.Options` fields

### Why:
These scaffolds provide a typed, (hopefully) convenient way of creating and updating resources. They'll be used by their respective resource clients, which will be introduced in future PRs.