### PR TITLE
feat(api): add Post method for dev convenience

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -58,15 +58,7 @@ func NewClient(client api.Client) *Client {
 
 // Create creates a new Address.
 func (ac *Client) Create(ctx context.Context, scaffold *scaffold.Address) (*Address, error) {
-	req, err := ac.client.NewRequest(ctx, "POST", basePath, scaffold)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := ac.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+	resp, err := ac.client.Post(ctx, basePath, scaffold)
 
 	addr := &Address{}
 	err = api.Deserialize(resp, addr)
@@ -101,12 +93,7 @@ func (ac *Client) Retrieve(ctx context.Context, id string) (*Address, error) {
 func (ac *Client) Delete(ctx context.Context, id string) error {
 	relPath := fmt.Sprintf("%s/%s", basePath, id)
 
-	req, err := ac.client.NewRequest(ctx, "DELETE", relPath, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := ac.client.Do(req)
+	resp, err := ac.client.Delete(ctx, relPath)
 	if err != nil {
 		return err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -25,6 +25,8 @@ type Client interface {
 	NewMultiformRequest(context.Context, string, string, *bytes.Buffer) (*http.Request, error)
 	Do(*http.Request) (*http.Response, error)
 	Get(context.Context, string) (*http.Response, error)
+	Post(context.Context, string, interface{}) (*http.Response, error)
+	Delete(context.Context, string) (*http.Response, error)
 }
 
 // JSONClient implements the Client interface and provides convenience methods for constructing
@@ -138,6 +140,34 @@ func (c *JSONClient) Do(req *http.Request) (*http.Response, error) {
 // Get provides a convenience wrapper for issuing http GET requests.
 func (c *JSONClient) Get(ctx context.Context, url string) (*http.Response, error) {
 	req, err := c.NewRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Post provides a convenience wrapper for issuing http POST requests with a JSON body.
+func (c *JSONClient) Post(ctx context.Context, url string, body interface{}) (*http.Response, error) {
+	req, err := c.NewRequest(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Delete provides a convenience wrapper for issuing http Delete requests.
+func (c *JSONClient) Delete(ctx context.Context, url string) (*http.Response, error) {
+	req, err := c.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What:
- Adds a convenience methods to the `api` package for issuing:
  - `POST` requests with JSON payloads
  - `DELETE` requests 

### Why:
Less boilerplate, more readable code. 