### PR TITLE
 feat(products): add idempotency key support to letters, postcards, and checks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,6 +19,9 @@ const (
 	defaultMaxQPS = 10
 	mediaType     = "application/json"
 	userAgent     = "LobGo/0.0.0" // TODO(damian): figure out how we want to handle versioning
+
+	// IdempotencyKeyHeader is the header string used when issuing idempotent requests.
+	IdempotencyKeyHeader = "Idempotency-Key"
 )
 
 // The Client interface defines methods for interacting with an HTTP API.

--- a/check/check.go
+++ b/check/check.go
@@ -95,6 +95,10 @@ func (cc *Client) Create(ctx context.Context, scfld *scaffold.Check) (*Check, er
 		}
 	}
 
+	if scfld.IdempotencyKey != "" {
+		req.Header.Add(api.IdempotencyKeyHeader, scfld.IdempotencyKey)
+	}
+
 	resp, err := cc.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -36,7 +36,8 @@ func TestCreateInline(t *testing.T) {
 	}
 
 	scaffold := &scaffold.Check{
-		To: to,
+		To:             to,
+		IdempotencyKey: "foo",
 	}
 
 	handler := func(rw http.ResponseWriter, req *http.Request) {
@@ -44,6 +45,9 @@ func TestCreateInline(t *testing.T) {
 			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		if req.Header.Get("Content-Type") != "application/json" {
+			http.Error(rw, "internal server error", http.StatusInternalServerError)
+		}
+		if req.Header.Get(api.IdempotencyKeyHeader) != "foo" {
 			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		io.WriteString(rw, fmt.Sprintf(`{"id":"%s", "to": %s}`, id, to.String()))

--- a/letter/letter.go
+++ b/letter/letter.go
@@ -88,6 +88,10 @@ func (lc *Client) Create(ctx context.Context, scfld *scaffold.Letter) (*Letter, 
 		}
 	}
 
+	if scfld.IdempotencyKey != "" {
+		req.Header.Add(api.IdempotencyKeyHeader, scfld.IdempotencyKey)
+	}
+
 	resp, err := lc.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/letter/letter_test.go
+++ b/letter/letter_test.go
@@ -36,7 +36,8 @@ func TestCreateInline(t *testing.T) {
 	}
 
 	scaffold := &scaffold.Letter{
-		To: to,
+		To:             to,
+		IdempotencyKey: "foo",
 	}
 
 	handler := func(rw http.ResponseWriter, req *http.Request) {
@@ -44,6 +45,9 @@ func TestCreateInline(t *testing.T) {
 			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		if req.Header.Get("Content-Type") != "application/json" {
+			http.Error(rw, "internal server error", http.StatusInternalServerError)
+		}
+		if req.Header.Get(api.IdempotencyKeyHeader) != "foo" {
 			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		io.WriteString(rw, fmt.Sprintf(`{"id":"%s", "to": %s}`, id, to.String()))

--- a/postcard/postcard.go
+++ b/postcard/postcard.go
@@ -85,6 +85,10 @@ func (pc *Client) Create(ctx context.Context, scfld *scaffold.Postcard) (*Postca
 		}
 	}
 
+	if scfld.IdempotencyKey != "" {
+		req.Header.Add(api.IdempotencyKeyHeader, scfld.IdempotencyKey)
+	}
+
 	resp, err := pc.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/postcard/postcard_test.go
+++ b/postcard/postcard_test.go
@@ -36,7 +36,8 @@ func TestCreateInline(t *testing.T) {
 	}
 
 	scaffold := &scaffold.Postcard{
-		To: to,
+		To:             to,
+		IdempotencyKey: "foo",
 	}
 
 	handler := func(rw http.ResponseWriter, req *http.Request) {
@@ -44,6 +45,9 @@ func TestCreateInline(t *testing.T) {
 			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		if req.Header.Get("Content-Type") != "application/json" {
+			http.Error(rw, "internal server error", http.StatusInternalServerError)
+		}
+		if req.Header.Get(api.IdempotencyKeyHeader) != "foo" {
 			http.Error(rw, "internal server error", http.StatusInternalServerError)
 		}
 		io.WriteString(rw, fmt.Sprintf(`{"id":"%s", "to": %s}`, id, to.String()))

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -50,6 +50,7 @@ type Check struct {
 	MailType       nullable.String   `json:"mail_type"`
 	SendDate       nullable.String   `json:"send_date"`
 	Metadata       map[string]string `json:"metadata"`
+	IdempotencyKey string            `json:"-"`
 }
 
 // Letter scaffold wraps fields used to create a Letter object in Lob API.
@@ -68,6 +69,7 @@ type Letter struct {
 	SendDate         nullable.String   `json:"send_date"`
 	Description      string            `json:"description"`
 	Metadata         map[string]string `json:"metadata"`
+	IdempotencyKey   string            `json:"-"`
 }
 
 // Postcard scaffold wraps fields used to create a Postcard object in Lob API.
@@ -82,6 +84,7 @@ type Postcard struct {
 	MailType       nullable.String   `json:"mail_type"`
 	SendDate       nullable.String   `json:"send_date"`
 	Metadata       map[string]string `json:"metadata"`
+	IdempotencyKey string            `json:"-"`
 }
 
 // MarshalAsFormValues attempts to coerce the fields of the given scaffold into strings,


### PR DESCRIPTION
### What: 
Checks if `IdempotencyKey` field on `letter`,`check`, and `postcard` scaffolds is set. If it is, we add an `Idempotency-Key` header to the `Create` request.

### Why: 
This adds `Idempotency-Key` support to the library.
